### PR TITLE
IPv6 address support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,5 @@ before_script:
 
 script:
  - go get
+ - go test -v
  - go build

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ of linux kernel. Using `koko`, you can simply make point-to-point connection for
 
 ![Koko's abstruct design](https://raw.githubusercontent.com/wiki/redhat-nfvpe/koko/images/koko.png)
 
+# Note
+
+From May 2016, option separator is changed from ':' to ',', due to support IPv6. Now README.md and wiki page is updated.
+
 # Support Container Type and Interfaces
 
 `koko` supports following container:
@@ -37,18 +41,19 @@ of linux kernel. Using `koko`, you can simply make point-to-point connection for
 
 ## Connecting containers in container host using veth
 
-    ./koko {-d <container>:<linkname>[:<IPv4 addr>/<prefixlen>] |
-            -n <netns name>:<linkname>[:<IPv4 addr>/<prefixlen>] }
-           {-d <container>:<linkname>[:<IPv4 addr>/<prefixlen>] |
-            -n <netns name>:<linkname>[:<IPv4 addr>/<prefixlen>] }
+    ./koko {-d <container>,<linkname>[,<IPv4 addr>/<prefixlen>[,<IPv6 addr>/<prefixlen>]] |
+            -n <netns name>,<linkname>[,<IPv4 addr>/<prefixlen>[,<IPv6 addr>/<prefixlen>]]}
+	   {-d <container>,<linkname>[,<IPv4 addr>/<prefixlen>[,<IPv6 addr>/<prefixlen>]] |
+            -n <netns name>,<linkname>[,<IPv4 addr>/<prefixlen>[,<IPv6 addr>/<prefixlen>]]}
+
 
 ## Connecting containers using vxlan (interconnecting container hosts)
 
 Connecting containers which are in separate hosts with vxlan. Following command makes vxlan interface 
 and put this interface into given container with/without IP address.
 
-    ./koko {-d <container>:<linkname>[:<IPv4 addr>/<prefixlen>] |
-            -n <netns name>:<linkname>[:<IPv4 addr>/<prefixlen>] }
+    ./koko {-d <container>,<linkname>[,<IPv4 addr>/<prefixlen>[,<IPv6 addr>/<prefixlen>]] |
+            -n <netns name>,<linkname>[,<IPv4 addr>/<prefixlen>[,<IPv6 addr>/<prefixlen>]] }
             -x <parent interface>:<remote endpoint IP addr>:<vxlan id> 
 
 ## Delete link in containers
@@ -56,7 +61,7 @@ and put this interface into given container with/without IP address.
 `koko -D` and `koko -N` deletes veth interface or vxlan interface. In case of veth, peering interface is also
 removed in this command.
 
-    ./koko {-D <container>:<linkname> | -N <netns name>:<linkname> }
+    ./koko {-D <container>,<linkname> | -N <netns name>,<linkname> }
 
 ## Printing help
 
@@ -68,13 +73,13 @@ Please see [Examples](https://github.com/redhat-nfvpe/koko/wiki/Examples) in Wik
 ## Example
 
     # connect between docker containers
-    sudo ./koko -d centos1:link1:192.168.1.1/24 -d centos2:link2:192.168.1.2/24
+    sudo ./koko -d centos1,link1,192.168.1.1/24 -d centos2,link2,192.168.1.2/24
     # connect between netns namespaces
-    sudo ./koko -n testns1:link1:192.168.1.1/24 -n testns2:link2:192.168.1.2/24
+    sudo ./koko -n testns1,link1,192.168.1.1/24 -n testns2,link2,192.168.1.2/24
     # connect between docker container and netns namespace
-    sudo ./koko -d centos1:link1:192.168.1.1/24 -n testns2:link2:192.168.1.2/24
+    sudo ./koko -d centos1,link1,192.168.1.1/24 -n testns2,link2,192.168.1.2/24
     # create vxlan interface and put it into docker container
-    sudo ./koko -d centos1:link1:192.168.1.1/24 -x eth1:10.1.1.1:1
+    sudo ./koko -d centos1,link1,192.168.1.1/24 -x eth1,10.1.1.1,1
 
 # Todo
 - Document

--- a/koko.go
+++ b/koko.go
@@ -68,16 +68,16 @@ func addVxLanInterface(vxlan vxLan, devName string) error {
 
 	vxlanconf := netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{
-				Name:		devName,
-				TxQLen:		1000,
+			Name:   devName,
+			TxQLen: 1000,
 		},
-		VxlanId:	vxlan.id,
-		VtepDevIndex:	parentIF.Attrs().Index,
-		Group:		vxlan.ipAddr,
-		Port:		4789,
-		Learning:	true,
-		L2miss:		true,
-		L3miss:		true,
+		VxlanId:      vxlan.id,
+		VtepDevIndex: parentIF.Attrs().Index,
+		Group:        vxlan.ipAddr,
+		Port:         4789,
+		Learning:     true,
+		L2miss:       true,
+		L3miss:       true,
 	}
 	err = netlink.LinkAdd(&vxlanconf)
 
@@ -113,19 +113,19 @@ func getDockerContainerNS(containerID string) (namespace string, err error) {
 
 // vEth is a structure to descrive veth interfaces.
 type vEth struct {
-	nsName		string		// What's the network namespace?
-	linkName	string		// And what will we call the link.
-	withIP4Addr	bool		// Is there an ipv4 address?
-	withIP6Addr	bool		// Is there an ipv6 address?
-	ip4Addr		net.IPNet	// What is that ip address.
-	ip6Addr		net.IPNet	// What is that ip address.
+	nsName      string    // What's the network namespace?
+	linkName    string    // And what will we call the link.
+	withIP4Addr bool      // Is there an ipv4 address?
+	withIP6Addr bool      // Is there an ipv6 address?
+	ip4Addr     net.IPNet // What is that ip address.
+	ip6Addr     net.IPNet // What is that ip address.
 }
 
 // vxLan is a structure to descrive vxlan endpoint.
 type vxLan struct {
-	parentIF	string		// parent interface name
-	id		int		// VxLan ID
-	ipAddr		net.IP		// VxLan destination address
+	parentIF string // parent interface name
+	id       int    // VxLan ID
+	ipAddr   net.IP // VxLan destination address
 }
 
 // setVethLink is low-level handler to set IP address onveth links given a single vEth data object.
@@ -198,7 +198,6 @@ func (veth *vEth) removeVethLink() (err error) {
 
 	return
 }
-
 
 // makeVeth is top-level handler to create veth links given two vEth data objects: veth1 and veth2.
 func makeVeth(veth1 vEth, veth2 vEth) {
@@ -360,7 +359,7 @@ Usage:
 * case1: connect between docker container, with ip address
 ./koko -d centos1:link1:192.168.1.1/24 -d centos2:link2:192.168.1.2/24
 * case2: connect between docker container, without ip address
-./koko -d centos1:link1 -d centos2:link2 
+./koko -d centos1:link1 -d centos2:link2
 * case3: connect between linux ns container (a.k.a. 'ip netns'), with ip address
 ./koko -n /var/run/netns/test1:link1:192.168.1.1/24 -n <snip>
 * case4: connect between linux ns and docker container
@@ -375,8 +374,8 @@ Usage:
 */
 func main() {
 
-	var c int		// command line parameters.
-	var err error		// if we encounter an error, it's marked here.
+	var c int     // command line parameters.
+	var err error // if we encounter an error, it's marked here.
 	const (
 		ModeUnspec = iota
 		ModeAddVeth

--- a/koko.go
+++ b/koko.go
@@ -115,8 +115,10 @@ func getDockerContainerNS(containerID string) (namespace string, err error) {
 type vEth struct {
 	nsName		string		// What's the network namespace?
 	linkName	string		// And what will we call the link.
-	withIPAddr	bool		// Is there an ip address?
-	ipAddr		net.IPNet	// What is that ip address.
+	withIP4Addr	bool		// Is there an ipv4 address?
+	withIP6Addr	bool		// Is there an ipv6 address?
+	ip4Addr		net.IPNet	// What is that ip address.
+	ip6Addr		net.IPNet	// What is that ip address.
 }
 
 // vxLan is a structure to descrive vxlan endpoint.
@@ -151,8 +153,8 @@ func (veth *vEth) setVethLink(link netlink.Link) (err error) {
 		}
 
 		// Conditionally set the IP address.
-		if veth.withIPAddr {
-			addr := &netlink.Addr{IPNet: &veth.ipAddr, Label: ""}
+		if veth.withIP4Addr {
+			addr := &netlink.Addr{IPNet: &veth.ip4Addr, Label: ""}
 			if err = netlink.AddrAdd(link, addr); err != nil {
 				return fmt.Errorf("failed to add IP addr %v to %q: %v", addr, veth.linkName, err)
 			}
@@ -242,11 +244,11 @@ func parseNOption(s string) (veth vEth, err error) {
 				n[2], err2)
 			return
 		}
-		veth.ipAddr.IP = ip
-		veth.ipAddr.Mask = mask.Mask
-		veth.withIPAddr = true
+		veth.ip4Addr.IP = ip
+		veth.ip4Addr.Mask = mask.Mask
+		veth.withIP4Addr = true
 	} else {
-		veth.withIPAddr = false
+		veth.withIP4Addr = false
 	}
 
 	return
@@ -274,11 +276,11 @@ func parseDOption(s string) (veth vEth, err error) {
 				n[2], err2)
 			return
 		}
-		veth.ipAddr.IP = ip
-		veth.ipAddr.Mask = mask.Mask
-		veth.withIPAddr = true
+		veth.ip4Addr.IP = ip
+		veth.ip4Addr.Mask = mask.Mask
+		veth.withIP4Addr = true
 	} else {
-		veth.withIPAddr = false
+		veth.withIP4Addr = false
 	}
 
 	return

--- a/koko_test.go
+++ b/koko_test.go
@@ -1,11 +1,11 @@
 package main
+
 import (
-	"testing"
 	"bytes"
 	"net"
 	"strings"
+	"testing"
 )
-
 
 func TestParseLinkIPOption(t *testing.T) {
 	// test case1: parse "-n testns,testlink"
@@ -13,45 +13,46 @@ func TestParseLinkIPOption(t *testing.T) {
 	linkName1 := "testlink"
 	veth1 := vEth{}
 
-	err1 := parseLinkIPOption(&veth1, strings.Split(str1,","))
+	err1 := parseLinkIPOption(&veth1, strings.Split(str1, ","))
 	if err1 != nil {
 		t.Fatalf("Parse error: %v", err1)
-	} 
+	}
 	if veth1.linkName != linkName1 {
 		t.Fatalf("nsName Parse error %s should be %s",
 			veth1.linkName, linkName1)
 	}
-	
+
 	// test case2: parse "testlink,192.168.1.1/24"
 	str2 := "testlink,192.168.1.1/24"
 	linkName2 := "testlink"
 	linkIp4Addr2 := net.ParseIP("192.168.1.1")
 	linkIp4Prefix2 := net.CIDRMask(24, 32)
 	veth2 := vEth{}
-	
-	err2 := parseLinkIPOption(&veth2, strings.Split(str2,","))
+
+	err2 := parseLinkIPOption(&veth2, strings.Split(str2, ","))
 	if err2 != nil {
 		t.Fatalf("Parse error: %v", err1)
-	} 
+	}
 	if veth2.linkName != linkName2 {
 		t.Fatalf("nsName Parse error %s should be %s",
 			veth2.nsName, linkName2)
 	}
-	if ! veth2.withIP4Addr {
-		t.Fatalf("withIP4Addr should be true but %v",  veth2.withIP4Addr)
+	if !veth2.withIP4Addr {
+		t.Fatalf("withIP4Addr should be true but %v",
+			veth2.withIP4Addr)
 	}
-	if ! veth2.ip4Addr.IP.Equal(linkIp4Addr2) {
+	if !veth2.ip4Addr.IP.Equal(linkIp4Addr2) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
 			veth2.ip4Addr.IP, linkIp4Addr2)
 	}
-	if  bytes.Compare(veth2.ip4Addr.Mask, linkIp4Prefix2) != 0 {
+	if bytes.Compare(veth2.ip4Addr.Mask, linkIp4Prefix2) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
 			veth2.ip4Addr.Mask, linkIp4Prefix2)
 	}
 	if veth2.withIP6Addr {
 		t.Fatal("withIP6Addr should be false")
 	}
-	
+
 	// test case3: parse "testlink,192.168.1.1/24,ff02::1/64"
 	str3 := "testlink,192.168.1.1/24,ff02::1/64"
 	linkName3 := "testlink"
@@ -60,35 +61,35 @@ func TestParseLinkIPOption(t *testing.T) {
 	linkIp6Addr3 := net.ParseIP("ff02::1")
 	linkIp6Prefix3 := net.CIDRMask(64, 128)
 	veth3 := vEth{}
-	
-	err3 := parseLinkIPOption(&veth3, strings.Split(str3,","))
+
+	err3 := parseLinkIPOption(&veth3, strings.Split(str3, ","))
 	if err3 != nil {
 		t.Fatalf("Parse error: %v", err1)
-	} 
+	}
 	if veth3.linkName != linkName3 {
 		t.Fatalf("nsName Parse error %s should be %s",
 			veth3.nsName, linkName3)
 	}
-	if ! veth3.withIP4Addr {
+	if !veth3.withIP4Addr {
 		t.Fatalf("withIP4Addr should be true")
 	}
-	if ! veth3.ip4Addr.IP.Equal(linkIp4Addr3) {
+	if !veth3.ip4Addr.IP.Equal(linkIp4Addr3) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
 			veth3.ip4Addr.IP, linkIp4Addr3)
 	}
-	if  bytes.Compare(veth3.ip4Addr.Mask, linkIp4Prefix3) != 0 {
+	if bytes.Compare(veth3.ip4Addr.Mask, linkIp4Prefix3) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
 			veth3.ip4Addr.Mask, linkIp4Prefix3)
 	}
-	if ! veth3.withIP6Addr {
+	if !veth3.withIP6Addr {
 		t.Fatal("withIP6Addr should be true")
 	}
-	if ! veth3.ip6Addr.IP.Equal(linkIp6Addr3) {
+	if !veth3.ip6Addr.IP.Equal(linkIp6Addr3) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
 			veth3.ip6Addr.IP, linkIp6Addr3)
 	}
-	if  bytes.Compare(veth3.ip6Addr.Mask, linkIp6Prefix3) != 0 {
-		t.Fatal("ip4Addr.Mask Parse error %s should be %s",
+	if bytes.Compare(veth3.ip6Addr.Mask, linkIp6Prefix3) != 0 {
+		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
 			veth3.ip6Addr.Mask, linkIp6Prefix3)
 	}
 
@@ -98,11 +99,11 @@ func TestParseLinkIPOption(t *testing.T) {
 	linkIp6Addr4 := net.ParseIP("ff02::1")
 	linkIp6Prefix4 := net.CIDRMask(64, 128)
 	veth4 := vEth{}
-	
-	err4 := parseLinkIPOption(&veth4, strings.Split(str4,","))
+
+	err4 := parseLinkIPOption(&veth4, strings.Split(str4, ","))
 	if err4 != nil {
 		t.Fatalf("Parse error: %v", err1)
-	} 
+	}
 	if veth4.linkName != linkName4 {
 		t.Fatalf("nsName Parse error %s should be %s",
 			veth4.nsName, linkName4)
@@ -110,16 +111,16 @@ func TestParseLinkIPOption(t *testing.T) {
 	if veth4.withIP4Addr {
 		t.Fatal("withIP4Addr should be false")
 	}
-	if ! veth4.withIP6Addr {
+	if !veth4.withIP6Addr {
 		t.Fatal("withIP6Addr should be true")
 	}
-	if ! veth4.ip6Addr.IP.Equal(linkIp6Addr4) {
+	if !veth4.ip6Addr.IP.Equal(linkIp6Addr4) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
 			veth4.ip6Addr.IP, linkIp6Addr4)
 	}
-	if  bytes.Compare(veth4.ip6Addr.Mask, linkIp6Prefix4) != 0 {
+	if bytes.Compare(veth4.ip6Addr.Mask, linkIp6Prefix4) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
 			veth4.ip6Addr.Mask, linkIp6Prefix4)
 	}
-	
+
 }

--- a/koko_test.go
+++ b/koko_test.go
@@ -25,8 +25,8 @@ func TestParseLinkIPOption(t *testing.T) {
 	// test case2: parse "testlink,192.168.1.1/24"
 	str2 := "testlink,192.168.1.1/24"
 	linkName2 := "testlink"
-	linkIp4Addr2 := net.ParseIP("192.168.1.1")
-	linkIp4Prefix2 := net.CIDRMask(24, 32)
+	linkIP4Addr2 := net.ParseIP("192.168.1.1")
+	linkIP4Prefix2 := net.CIDRMask(24, 32)
 	veth2 := vEth{}
 
 	err2 := parseLinkIPOption(&veth2, strings.Split(str2, ","))
@@ -41,13 +41,13 @@ func TestParseLinkIPOption(t *testing.T) {
 		t.Fatalf("withIP4Addr should be true but %v",
 			veth2.withIP4Addr)
 	}
-	if !veth2.ip4Addr.IP.Equal(linkIp4Addr2) {
+	if !veth2.ip4Addr.IP.Equal(linkIP4Addr2) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
-			veth2.ip4Addr.IP, linkIp4Addr2)
+			veth2.ip4Addr.IP, linkIP4Addr2)
 	}
-	if bytes.Compare(veth2.ip4Addr.Mask, linkIp4Prefix2) != 0 {
+	if bytes.Compare(veth2.ip4Addr.Mask, linkIP4Prefix2) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
-			veth2.ip4Addr.Mask, linkIp4Prefix2)
+			veth2.ip4Addr.Mask, linkIP4Prefix2)
 	}
 	if veth2.withIP6Addr {
 		t.Fatal("withIP6Addr should be false")
@@ -56,10 +56,10 @@ func TestParseLinkIPOption(t *testing.T) {
 	// test case3: parse "testlink,192.168.1.1/24,ff02::1/64"
 	str3 := "testlink,192.168.1.1/24,ff02::1/64"
 	linkName3 := "testlink"
-	linkIp4Addr3 := net.ParseIP("192.168.1.1")
-	linkIp4Prefix3 := net.CIDRMask(24, 32)
-	linkIp6Addr3 := net.ParseIP("ff02::1")
-	linkIp6Prefix3 := net.CIDRMask(64, 128)
+	linkIP4Addr3 := net.ParseIP("192.168.1.1")
+	linkIP4Prefix3 := net.CIDRMask(24, 32)
+	linkIP6Addr3 := net.ParseIP("ff02::1")
+	linkIP6Prefix3 := net.CIDRMask(64, 128)
 	veth3 := vEth{}
 
 	err3 := parseLinkIPOption(&veth3, strings.Split(str3, ","))
@@ -73,31 +73,31 @@ func TestParseLinkIPOption(t *testing.T) {
 	if !veth3.withIP4Addr {
 		t.Fatalf("withIP4Addr should be true")
 	}
-	if !veth3.ip4Addr.IP.Equal(linkIp4Addr3) {
+	if !veth3.ip4Addr.IP.Equal(linkIP4Addr3) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
-			veth3.ip4Addr.IP, linkIp4Addr3)
+			veth3.ip4Addr.IP, linkIP4Addr3)
 	}
-	if bytes.Compare(veth3.ip4Addr.Mask, linkIp4Prefix3) != 0 {
+	if bytes.Compare(veth3.ip4Addr.Mask, linkIP4Prefix3) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
-			veth3.ip4Addr.Mask, linkIp4Prefix3)
+			veth3.ip4Addr.Mask, linkIP4Prefix3)
 	}
 	if !veth3.withIP6Addr {
 		t.Fatal("withIP6Addr should be true")
 	}
-	if !veth3.ip6Addr.IP.Equal(linkIp6Addr3) {
+	if !veth3.ip6Addr.IP.Equal(linkIP6Addr3) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
-			veth3.ip6Addr.IP, linkIp6Addr3)
+			veth3.ip6Addr.IP, linkIP6Addr3)
 	}
-	if bytes.Compare(veth3.ip6Addr.Mask, linkIp6Prefix3) != 0 {
+	if bytes.Compare(veth3.ip6Addr.Mask, linkIP6Prefix3) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
-			veth3.ip6Addr.Mask, linkIp6Prefix3)
+			veth3.ip6Addr.Mask, linkIP6Prefix3)
 	}
 
 	// test case4: parse "testlink,,ff02::1/64"
 	str4 := "testlink,,ff02::1/64"
 	linkName4 := "testlink"
-	linkIp6Addr4 := net.ParseIP("ff02::1")
-	linkIp6Prefix4 := net.CIDRMask(64, 128)
+	linkIP6Addr4 := net.ParseIP("ff02::1")
+	linkIP6Prefix4 := net.CIDRMask(64, 128)
 	veth4 := vEth{}
 
 	err4 := parseLinkIPOption(&veth4, strings.Split(str4, ","))
@@ -114,13 +114,13 @@ func TestParseLinkIPOption(t *testing.T) {
 	if !veth4.withIP6Addr {
 		t.Fatal("withIP6Addr should be true")
 	}
-	if !veth4.ip6Addr.IP.Equal(linkIp6Addr4) {
+	if !veth4.ip6Addr.IP.Equal(linkIP6Addr4) {
 		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
-			veth4.ip6Addr.IP, linkIp6Addr4)
+			veth4.ip6Addr.IP, linkIP6Addr4)
 	}
-	if bytes.Compare(veth4.ip6Addr.Mask, linkIp6Prefix4) != 0 {
+	if bytes.Compare(veth4.ip6Addr.Mask, linkIP6Prefix4) != 0 {
 		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
-			veth4.ip6Addr.Mask, linkIp6Prefix4)
+			veth4.ip6Addr.Mask, linkIP6Prefix4)
 	}
 
 }

--- a/koko_test.go
+++ b/koko_test.go
@@ -1,0 +1,125 @@
+package main
+import (
+	"testing"
+	"bytes"
+	"net"
+	"strings"
+)
+
+
+func TestParseLinkIPOption(t *testing.T) {
+	// test case1: parse "-n testns,testlink"
+	str1 := "testlink"
+	linkName1 := "testlink"
+	veth1 := vEth{}
+
+	err1 := parseLinkIPOption(&veth1, strings.Split(str1,","))
+	if err1 != nil {
+		t.Fatalf("Parse error: %v", err1)
+	} 
+	if veth1.linkName != linkName1 {
+		t.Fatalf("nsName Parse error %s should be %s",
+			veth1.linkName, linkName1)
+	}
+	
+	// test case2: parse "testlink,192.168.1.1/24"
+	str2 := "testlink,192.168.1.1/24"
+	linkName2 := "testlink"
+	linkIp4Addr2 := net.ParseIP("192.168.1.1")
+	linkIp4Prefix2 := net.CIDRMask(24, 32)
+	veth2 := vEth{}
+	
+	err2 := parseLinkIPOption(&veth2, strings.Split(str2,","))
+	if err2 != nil {
+		t.Fatalf("Parse error: %v", err1)
+	} 
+	if veth2.linkName != linkName2 {
+		t.Fatalf("nsName Parse error %s should be %s",
+			veth2.nsName, linkName2)
+	}
+	if ! veth2.withIP4Addr {
+		t.Fatalf("withIP4Addr should be true but %v",  veth2.withIP4Addr)
+	}
+	if ! veth2.ip4Addr.IP.Equal(linkIp4Addr2) {
+		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
+			veth2.ip4Addr.IP, linkIp4Addr2)
+	}
+	if  bytes.Compare(veth2.ip4Addr.Mask, linkIp4Prefix2) != 0 {
+		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
+			veth2.ip4Addr.Mask, linkIp4Prefix2)
+	}
+	if veth2.withIP6Addr {
+		t.Fatal("withIP6Addr should be false")
+	}
+	
+	// test case3: parse "testlink,192.168.1.1/24,ff02::1/64"
+	str3 := "testlink,192.168.1.1/24,ff02::1/64"
+	linkName3 := "testlink"
+	linkIp4Addr3 := net.ParseIP("192.168.1.1")
+	linkIp4Prefix3 := net.CIDRMask(24, 32)
+	linkIp6Addr3 := net.ParseIP("ff02::1")
+	linkIp6Prefix3 := net.CIDRMask(64, 128)
+	veth3 := vEth{}
+	
+	err3 := parseLinkIPOption(&veth3, strings.Split(str3,","))
+	if err3 != nil {
+		t.Fatalf("Parse error: %v", err1)
+	} 
+	if veth3.linkName != linkName3 {
+		t.Fatalf("nsName Parse error %s should be %s",
+			veth3.nsName, linkName3)
+	}
+	if ! veth3.withIP4Addr {
+		t.Fatalf("withIP4Addr should be true")
+	}
+	if ! veth3.ip4Addr.IP.Equal(linkIp4Addr3) {
+		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
+			veth3.ip4Addr.IP, linkIp4Addr3)
+	}
+	if  bytes.Compare(veth3.ip4Addr.Mask, linkIp4Prefix3) != 0 {
+		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
+			veth3.ip4Addr.Mask, linkIp4Prefix3)
+	}
+	if ! veth3.withIP6Addr {
+		t.Fatal("withIP6Addr should be true")
+	}
+	if ! veth3.ip6Addr.IP.Equal(linkIp6Addr3) {
+		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
+			veth3.ip6Addr.IP, linkIp6Addr3)
+	}
+	if  bytes.Compare(veth3.ip6Addr.Mask, linkIp6Prefix3) != 0 {
+		t.Fatal("ip4Addr.Mask Parse error %s should be %s",
+			veth3.ip6Addr.Mask, linkIp6Prefix3)
+	}
+
+	// test case4: parse "testlink,,ff02::1/64"
+	str4 := "testlink,,ff02::1/64"
+	linkName4 := "testlink"
+	linkIp6Addr4 := net.ParseIP("ff02::1")
+	linkIp6Prefix4 := net.CIDRMask(64, 128)
+	veth4 := vEth{}
+	
+	err4 := parseLinkIPOption(&veth4, strings.Split(str4,","))
+	if err4 != nil {
+		t.Fatalf("Parse error: %v", err1)
+	} 
+	if veth4.linkName != linkName4 {
+		t.Fatalf("nsName Parse error %s should be %s",
+			veth4.nsName, linkName4)
+	}
+	if veth4.withIP4Addr {
+		t.Fatal("withIP4Addr should be false")
+	}
+	if ! veth4.withIP6Addr {
+		t.Fatal("withIP6Addr should be true")
+	}
+	if ! veth4.ip6Addr.IP.Equal(linkIp6Addr4) {
+		t.Fatalf("ip4Addr.IP Parse error %s should be %s",
+			veth4.ip6Addr.IP, linkIp6Addr4)
+	}
+	if  bytes.Compare(veth4.ip6Addr.Mask, linkIp6Prefix4) != 0 {
+		t.Fatalf("ip4Addr.Mask Parse error %s should be %s",
+			veth4.ip6Addr.Mask, linkIp6Prefix4)
+	}
+	
+}


### PR DESCRIPTION
Add code to support IPv6 address assign in container interface as well as unit test code.
This changes includes command-line option format change (comma is newly used instead of colon).