### PR TITLE
Add acceptance tests WIP

### DIFF
--- a/tests/acceptance.bats
+++ b/tests/acceptance.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+setup() {
+# Create dockers and namespaces
+    DOCKER1="$(docker run --rm -d -it alpine sh)"
+    DOCKER2="$(docker run --rm -d -it alpine sh)"
+    sudo ip netns add NS1
+    sudo ip netns add NS2
+}
+
+teardown() {
+# Delete dockers and namespaces
+    docker rm -f $DOCKER1
+    docker rm -f $DOCKER2
+    sudo ip netns del NS1
+    sudo ip netns del NS2
+}
+
+
+
+@test "Docker .. Docker" {
+      sudo ./koko -d $DOCKER1,vethD1D2,10.10.10.1/29 \
+             -d $DOCKER2,vethD2D1,10.10.10.2/29
+      run docker exec $DOCKER1 ping -c 3 -w 5 10.10.10.2  
+      [ "$status" -eq 0 ]
+}
+
+@test "netns .. netns" {
+      sudo ./koko -n NS1,vethNS1NS2,10.10.10.1/29 \
+                  -n NS2,vethNS2NS1,10.10.10.2/29
+      run sudo ip netns exec NS1 ping -c 3 -w 5 10.10.10.2  
+      [ "$status" -eq 0 ]
+}
+
+@test "Docker .. netns" {
+      skip
+      echo "TODO"
+}
+
+@test "Docker .. Docker (VXLAN)" {
+      skip
+      echo "TODO"
+}
+
+
+@test "netns .. netns (VXLAN)" {
+      skip
+      echo "TODO"
+}
+
+@test "Docker .. netns (VXLAN)" {
+      skip
+      echo "TODO"
+}
+
+@test "Docker .. VLAN" {
+      skip
+      echo "TODO"
+}
+
+@test "netns .. VLAN" {
+      skip
+      echo "TODO"
+}
+
+@test "Docker .. macvlan" {
+      skip
+      echo "TODO"
+}
+
+
+@test "Docker .. Docker (Mirroring)" {
+      skip
+      echo "TODO"
+}
+
+
+@test "Docker .. VXLAN (Mirroring)" {
+      skip
+      echo "TODO"
+}

--- a/tests/acceptanceIPv4.bats
+++ b/tests/acceptanceIPv4.bats
@@ -1,4 +1,6 @@
 #!/usr/bin/env bats
+# Acceptance test script for each command line options with IPv4.
+# https://github.com/redhat-nfvpe/koko/wiki/Examples
 
 setup() {
 # Create dockers and namespaces


### PR DESCRIPTION
This patchs add acceptance tests using [bats](https://github.com/sstephenson/bats).

The tests are based on the scenarios described
in the [wiki](https://github.com/redhat-nfvpe/koko/wiki/Examples)

You only need to install bats and run it in the same folder as the
`koko` binary.

```sh
$ bats tests/acceptance.bats

 ✓ Docker .. Docker
 ✓ netns .. netns
 - Docker .. netns (skipped)
 - Docker .. Docker (VXLAN) (skipped)
 - netns .. netns (VXLAN) (skipped)
 - Docker .. netns (VXLAN) (skipped)
 - Docker .. VLAN (skipped)
 - netns .. VLAN (skipped)
 - Docker .. macvlan (skipped)
 - Docker .. Docker (Mirroring) (skipped)
 - Docker .. VXLAN (Mirroring) (skipped)

11 tests, 0 failures, 9 skipped
```

Signed-off-by: aojea <antonio.ojea.garcia@gmail.com>