### PR TITLE
Add veth cleanup routine in case of error

### DIFF
--- a/api/koko_api.go
+++ b/api/koko_api.go
@@ -506,9 +506,13 @@ func MakeVeth(veth1 VEth, veth2 VEth) error {
 	}
 
 	if err := veth1.SetVethLink(link1); err != nil {
+		netlink.LinkDel(link1)
 		return err
 	}
-	return veth2.SetVethLink(link2)
+	if err := veth2.SetVethLink(link2); err != nil {
+		netlink.LinkDel(link2)
+	}
+	return err
 }
 
 // MakeVxLan makes vxlan interface and put it into container namespace


### PR DESCRIPTION
This change adds veth cleanup routine in case of error at veth
config. This comes from @networkop's comment at #42.